### PR TITLE
webrtc/: Add message framing to support half-close and reset of stream

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -287,9 +287,10 @@ package webrtc.pb;
 message Message {
   enum Flag {
     // The sender will no longer send messages.
-    CLOSE_WRITE = 0;
-    // The sender will no longer read messages.
-    CLOSE_READ = 1;
+    FIN = 0;
+    // The sender will no longer read messages. Incoming data is being
+    // discarded on receipt.
+    STOP_SENDING = 1;
     // The local endpoint abruptly terminates the stream. The remote endpoint
     // may discard any in-flight data.
     RESET = 2;

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -276,7 +276,7 @@ libp2p](https://github.com/libp2p/specs/blob/master/connections/README.md#defini
 
 To support half-closing and resets of streams, libp2p WebRTC uses message
 framing. Messages on a `RTCDataChannel` are embedded into the Protobuf message
-below and send on the `RTCDataChannel` prefixed with the message length in
+below and sent on the `RTCDataChannel` prefixed with the message length in
 bytes, encoded as an unsigned variable length integer as defined by the
 [multiformats unsigned-varint spec][uvarint-spec].
 
@@ -386,7 +386,7 @@ sending _flagged_ messages.
   (`(5 bytes + 2 bytes) / 40 bytes = 0.175`) but likely irrelevant.
 
   Using Protobuf allows us to evolve the protocol in a backwards compatibile way
-  going forward. Using Protobuf is consisten with the many other libp2p
+  going forward. Using Protobuf is consistent with the many other libp2p
   protocols. These benefits outweigh the drawback of additional overhead.
 
 [QUIC RFC]: https://www.rfc-editor.org/rfc/rfc9000.html

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -280,6 +280,9 @@ below and sent on the `RTCDataChannel` prefixed with the message length in
 bytes, encoded as an unsigned variable length integer as defined by the
 [multiformats unsigned-varint spec][uvarint-spec].
 
+It is an adaptation from the [QUIC RFC]. When in doubt on the semantics of
+these messages, consult the [QUIC RFC].
+
 ``` proto
 syntax = "proto2";
 
@@ -303,8 +306,9 @@ message Message {
 }
 ```
 
-The above is adapted from the [QUIC RFC]. When in doubt on the semantics of
-these messages, consult the [QUIC RFC].
+Note that "a STOP_SENDING frame requests that the receiving endpoint send a
+RESET_STREAM frame.". See [QUIC RFC - 3.5 Solicited State
+Transitions](https://www.rfc-editor.org/rfc/rfc9000.html#section-3.5).
 
 Encoded messages including their length prefix MUST NOT exceed 16kiB to support
 all major browsers. See ["Understanding message size

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -286,13 +286,13 @@ package webrtc.pb;
 
 message Message {
   enum Flag {
-    // The sender will no longer send messages.
+    // The sender will no longer send messages on the stream.
     FIN = 0;
-    // The sender will no longer read messages. Incoming data is being
-    // discarded on receipt.
+    // The sender will no longer read messages on the stream. Incoming data is
+    // being discarded on receipt.
     STOP_SENDING = 1;
-    // The local endpoint abruptly terminates the stream. The remote endpoint
-    // may discard any in-flight data.
+    // The sender abruptly terminates the sending part of the stream. The
+    // receiver can discard any data that it already received on that stream.
     RESET = 2;
   }
 

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -264,7 +264,8 @@ be the same. On mismatch the final Noise handshake MUST fail.
 
 Following [Connection Security](#connection-security).
 
-The WebRTC browser APIs do not support half-closing nor resets of streams.
+The WebRTC browser APIs do not support half-closing of streams nor resets of the
+sending part of streams.
 [`RTCDataChannel.close()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/close)
 flushes the remaining messages and closes the local write and read side. After
 calling `RTCDataChannel.close()` one can no longer read from the channel. This

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -119,7 +119,7 @@ fingerprint](https://www.w3.org/TR/webrtc/#dom-rtccertificate-getfingerprints).
 7. Messages on an `RTCDataChannel` are framed using the message framing
    mechanism described in [Multiplexing](#multiplexing).
 
-7. The remote is authenticated via an additional Noise handshake. See
+8. The remote is authenticated via an additional Noise handshake. See
    [Connection Security](#connection-security).
 
 #### Open Questions

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -297,7 +297,7 @@ message Message {
     STOP_SENDING = 1;
     // The sender abruptly terminates the sending part of the stream. The
     // receiver can discard any data that it already received on that stream.
-    RESET = 2;
+    RESET_STREAM = 2;
   }
 
   optional Flag flag=1;

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -302,6 +302,9 @@ message Message {
 }
 ```
 
+The above is adapted from the [QUIC RFC]. When in doubt on the semantics of
+these messages, consult the [QUIC RFC].
+
 Encoded messages including their length prefix MUST NOT exceed 16kiB to support
 all major browsers. See ["Understanding message size
 limits"](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Using_data_channels#understanding_message_size_limits).
@@ -384,3 +387,5 @@ sending _flagged_ messages.
   Using Protobuf allows us to evolve the protocol in a backwards compatibile way
   going forward. Using Protobuf is consisten with the many other libp2p
   protocols. These benefits outweigh the drawback of additional overhead.
+
+[QUIC RFC]: https://www.rfc-editor.org/rfc/rfc9000.html

--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -286,9 +286,9 @@ package webrtc.pb;
 
 message Message {
   enum Flag {
-    // The local endpoint will no longer send messages.
+    // The sender will no longer send messages.
     CLOSE_WRITE = 0;
-    // The local endpoint will no longer read messages.
+    // The sender will no longer read messages.
     CLOSE_READ = 1;
     // The local endpoint abruptly terminates the stream. The remote endpoint
     // may discard any in-flight data.


### PR DESCRIPTION
_Note this pull request targets https://github.com/libp2p/specs/pull/412 and not the master branch._

The WebRTC browser APIs do not support half-closing nor resets of streams. This
commit defines a message framing schema to support this functionality on top of
the browser APIs.

This is a first proposal. This has not yet been implemented and will thus most likely change.

Input very much appreciated.

See https://github.com/libp2p/specs/pull/412#discussion_r932487837 and https://github.com/libp2p/specs/pull/412#issuecomment-1209246438 for past discussions on this topic.