### PR TITLE
webrtc: Don't use multihash for noise prologue

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -300,8 +300,7 @@ After [Connection Establishment](#connection-establishment):
    specifically _A_ and _B_ set the Noise _Prologue_ to
    `libp2p-webrtc-noise:<FINGERPRINTS>` before starting the actual Noise
    handshake. `<FINGERPRINTS>` is the concatenation of the two TLS fingerprints
-   of _A_ and _B_ in their multihash byte representation, sorted in ascending
-   order.
+   of _A_ and _B_ sorted in ascending order.
 
   On Chrome _A_ can access its TLS certificate fingerprint directly via
   `RTCCertificate#getFingerprints`. Firefox does not allow _A_ to do so. Browser


### PR DESCRIPTION
As elaborated in [this](https://github.com/libp2p/specs/pull/412#discussion_r984124897) comment, I don't think the use of multihash gives us any value here.

Both peers need to know the hash algorithm in advance and they never get to look at the wrapped hash of the other party. As such, they can't learn any information from it, so I think the use of a self-describing format doesn't make any sense.

The only thing I can think of that the use of multihash might guard against is that two different hash algorithms could produce the same hash for different certificates. I am not even sure such kinds of collisions are possible?