### PR TITLE
Clarify reset behaviour

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -260,8 +260,8 @@ message Message {
     // The sender will no longer read messages on the stream. Incoming data is
     // being discarded on receipt.
     STOP_SENDING = 1;
-    // The sender abruptly terminates the sending part of the stream. The
-    // receiver can discard any data that it already received on that stream.
+    // The sender abruptly terminates the entire stream. The stream is unusable
+    // after a reset and any received data SHOULD be discarded.
     RESET_STREAM = 2;
   }
 


### PR DESCRIPTION
Aborting the entire stream is what `mplex` and `yamux` do. See https://github.com/libp2p/specs/issues/466 for details.